### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,17 +47,17 @@ else
 EXE =
 endif
 
-CC      := g++
+CC      := ${CXX}
 
 BASEFLAGS  := -Wall -Wextra ${INCDIRS} $(MARCH) \
  -D_REENTRANT -fno-exceptions -fno-rtti
 
-GCCVER5 := $(shell expr `g++ -dumpversion | cut -f1 -d.` \>= 5)
+GCCVER5 := $(shell expr `${CXX} -dumpversion | cut -f1 -d.` \>= 5)
 ifeq "$(GCCVER5)" "1"
  BASEFLAGS += -Wno-implicit-fallthrough
 endif
 
-GCCVER8 := $(shell expr `g++ -dumpversion | cut -f1 -d.` \>= 8)
+GCCVER8 := $(shell expr `${CXX} -dumpversion | cut -f1 -d.` \>= 8)
 ifeq "$(GCCVER8)" "1"
   BASEFLAGS += -Wno-class-memaccess
 endif


### PR DESCRIPTION
Add fixes to the makefile outlined [here](https://f1000research.com/articles/9-304/v1#referee-response-62867) that address the generation of a lot of warnings with newer compilers (e.g. gcc-9).